### PR TITLE
Added scroll_time modifier for speed hack plugin

### DIFF
--- a/src/plugins/keyHijacker/keyHijacker.cpp
+++ b/src/plugins/keyHijacker/keyHijacker.cpp
@@ -226,7 +226,7 @@ _declspec(naked) void checkKeysNaked()
 
 void setScrollMultiplier()
 {
-	scrollTimeMultiplier = std::pow(1.1f, (g_hackedSpeed - 1)*2);
+	scrollTimeMultiplier = std::pow(g_hackedSpeed, 4);
 }
 
 _declspec(naked) void changeScrollTimeNaked()


### PR DESCRIPTION
Changes a function in game that loads the scroll time value in game. It then multiplies it by a multiplier to simulate hyperspeed changes.

This ensures that when the speedhack is activated, the notes are not scrolling too fast to see them and it should look (in theory) the same as it would if you used a 150% chart instead of the hack.